### PR TITLE
chore(api, types): move `getExpressionContext` and `expressionContext…

### DIFF
--- a/apps/app/src/app/sentence-training/[expressionContextId]/page.tsx
+++ b/apps/app/src/app/sentence-training/[expressionContextId]/page.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react";
 import { Spinner } from "@/components/ui/spinner";
-import { getExpressionContext } from "@/features/sentence-training/actions";
 import { notFound } from "next/navigation";
 import { SentenceTrainer } from "@/features/sentence-training/components/sentence-trainer";
+import { getExpressionContext } from "@/features/dictionary/actions";
 
 type Props = Readonly<{
   params: Promise<{ expressionContextId: string }>;

--- a/apps/app/src/features/dictionary/actions.ts
+++ b/apps/app/src/features/dictionary/actions.ts
@@ -1,0 +1,23 @@
+import { authFetch } from "@/lib/auth-fetch";
+import { BACKEND_URL } from "@/lib/constants";
+import { expressionContextSchema } from "@/features/dictionary/types";
+
+export async function getExpressionContext(expressionContextId: string) {
+  try {
+    const response = await authFetch(
+      `${BACKEND_URL}/dictionary/expression-contexts/${expressionContextId}`,
+      {
+        method: "GET",
+        headers: {
+          "Content-Type": "application/json",
+        },
+      },
+    );
+
+    const data = await response.json();
+    return expressionContextSchema.parse(data);
+  } catch (error) {
+    console.error("Error in getExpressionContext:", error);
+    throw error;
+  }
+}

--- a/apps/app/src/features/dictionary/types.ts
+++ b/apps/app/src/features/dictionary/types.ts
@@ -1,0 +1,23 @@
+import { z } from "zod";
+import { expressionContextTypeSchema } from "@/lib/types";
+
+const sentenceSchema = z.object({
+  sentenceId: z.string(),
+  content: z.string(),
+  translation: z.string(),
+});
+
+export const expressionContextSchema = z.object({
+  expressionContextId: z.string(),
+  expressionId: z.string(),
+  phrase: z.string(),
+  translation: z.string(),
+  type: expressionContextTypeSchema,
+  isIrregular: z.boolean(),
+  isCountable: z.boolean(),
+  definition: z.string().nullable(),
+  definitionTranslation: z.string().nullable(),
+  sentences: z.array(sentenceSchema),
+});
+
+export type ExpressionContext = z.infer<typeof expressionContextSchema>;

--- a/apps/app/src/features/sentence-training/actions.ts
+++ b/apps/app/src/features/sentence-training/actions.ts
@@ -1,31 +1,8 @@
 "use server";
 
-import {
-  expressionContextSchema,
-  validateSentenceResponseSchema,
-} from "@/features/sentence-training/types";
+import { validateSentenceResponseSchema } from "@/features/sentence-training/types";
 import { authFetch } from "@/lib/auth-fetch";
 import { BACKEND_URL } from "@/lib/constants";
-
-export async function getExpressionContext(expressionContextId: string) {
-  try {
-    const response = await authFetch(
-      `${BACKEND_URL}/dictionary/expression-contexts/${expressionContextId}`,
-      {
-        method: "GET",
-        headers: {
-          "Content-Type": "application/json",
-        },
-      },
-    );
-
-    const data = await response.json();
-    return expressionContextSchema.parse(data);
-  } catch (error) {
-    console.error("Error in getExpressionContext:", error);
-    throw error;
-  }
-}
 
 export async function validateSentence(
   expressionContextId: string,

--- a/apps/app/src/features/sentence-training/types.ts
+++ b/apps/app/src/features/sentence-training/types.ts
@@ -1,26 +1,4 @@
-import { expressionContextTypeSchema } from "@/lib/types";
 import { z } from "zod";
-
-const sentenceSchema = z.object({
-  sentenceId: z.string(),
-  content: z.string(),
-  translation: z.string(),
-});
-
-export const expressionContextSchema = z.object({
-  expressionContextId: z.string(),
-  expressionId: z.string(),
-  phrase: z.string(),
-  translation: z.string(),
-  type: expressionContextTypeSchema,
-  isIrregular: z.boolean(),
-  isCountable: z.boolean(),
-  definition: z.string().nullable(),
-  definitionTranslation: z.string().nullable(),
-  sentences: z.array(sentenceSchema),
-});
-
-export type ExpressionContext = z.infer<typeof expressionContextSchema>;
 
 export const validateSentenceResponseSchema = z.object({
   score: z.number(),


### PR DESCRIPTION
…Schema` to dictionary module