### PR TITLE
Bump `turbo` dependency to version 2.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "husky": "^9.1.7",
         "localtunnel": "^2.0.2",
         "prettier": "^3.6.2",
-        "turbo": "^2.6.1",
+        "turbo": "^2.7.5",
         "typescript": "5.9.2"
       },
       "engines": {
@@ -20692,9 +20692,9 @@
       "license": "0BSD"
     },
     "node_modules/turbo": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.6.1.tgz",
-      "integrity": "sha512-qBwXXuDT3rA53kbNafGbT5r++BrhRgx3sAo0cHoDAeG9g1ItTmUMgltz3Hy7Hazy1ODqNpR+C7QwqL6DYB52yA==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/turbo/-/turbo-2.7.5.tgz",
+      "integrity": "sha512-7Imdmg37joOloTnj+DPrab9hIaQcDdJ5RwSzcauo/wMOSAgO+A/I/8b3hsGGs6PWQz70m/jkPgdqWsfNKtwwDQ==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -20702,18 +20702,18 @@
         "turbo": "bin/turbo"
       },
       "optionalDependencies": {
-        "turbo-darwin-64": "2.6.1",
-        "turbo-darwin-arm64": "2.6.1",
-        "turbo-linux-64": "2.6.1",
-        "turbo-linux-arm64": "2.6.1",
-        "turbo-windows-64": "2.6.1",
-        "turbo-windows-arm64": "2.6.1"
+        "turbo-darwin-64": "2.7.5",
+        "turbo-darwin-arm64": "2.7.5",
+        "turbo-linux-64": "2.7.5",
+        "turbo-linux-arm64": "2.7.5",
+        "turbo-windows-64": "2.7.5",
+        "turbo-windows-arm64": "2.7.5"
       }
     },
     "node_modules/turbo-darwin-64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.6.1.tgz",
-      "integrity": "sha512-Dm0HwhyZF4J0uLqkhUyCVJvKM9Rw7M03v3J9A7drHDQW0qAbIGBrUijQ8g4Q9Cciw/BXRRd8Uzkc3oue+qn+ZQ==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-64/-/turbo-darwin-64-2.7.5.tgz",
+      "integrity": "sha512-nN3wfLLj4OES/7awYyyM7fkU8U8sAFxsXau2bYJwAWi6T09jd87DgHD8N31zXaJ7LcpyppHWPRI2Ov9MuZEwnQ==",
       "cpu": [
         "x64"
       ],
@@ -20725,9 +20725,9 @@
       ]
     },
     "node_modules/turbo-darwin-arm64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.6.1.tgz",
-      "integrity": "sha512-U0PIPTPyxdLsrC3jN7jaJUwgzX5sVUBsKLO7+6AL+OASaa1NbT1pPdiZoTkblBAALLP76FM0LlnsVQOnmjYhyw==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/turbo-darwin-arm64/-/turbo-darwin-arm64-2.7.5.tgz",
+      "integrity": "sha512-wCoDHMiTf3FgLAbZHDDx/unNNonSGhsF5AbbYODbxnpYyoKDpEYacUEPjZD895vDhNvYCH0Nnk24YsP4n/cD6g==",
       "cpu": [
         "arm64"
       ],
@@ -20739,9 +20739,9 @@
       ]
     },
     "node_modules/turbo-linux-64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.6.1.tgz",
-      "integrity": "sha512-eM1uLWgzv89bxlK29qwQEr9xYWBhmO/EGiH22UGfq+uXr+QW1OvNKKMogSN65Ry8lElMH4LZh0aX2DEc7eC0Mw==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/turbo-linux-64/-/turbo-linux-64-2.7.5.tgz",
+      "integrity": "sha512-KKPvhOmJMmzWj/yjeO4LywkQ85vOJyhru7AZk/+c4B6OUh/odQ++SiIJBSbTG2lm1CuV5gV5vXZnf/2AMlu3Zg==",
       "cpu": [
         "x64"
       ],
@@ -20753,9 +20753,9 @@
       ]
     },
     "node_modules/turbo-linux-arm64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.6.1.tgz",
-      "integrity": "sha512-MFFh7AxAQAycXKuZDrbeutfWM5Ep0CEZ9u7zs4Hn2FvOViTCzIfEhmuJou3/a5+q5VX1zTxQrKGy+4Lf5cdpsA==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/turbo-linux-arm64/-/turbo-linux-arm64-2.7.5.tgz",
+      "integrity": "sha512-8PIva4L6BQhiPikUTds9lSFSHXVDAsEvV6QUlgwPsXrtXVQMVi6Sv9p+IxtlWQFvGkdYJUgX9GnK2rC030Xcmw==",
       "cpu": [
         "arm64"
       ],
@@ -20767,9 +20767,9 @@
       ]
     },
     "node_modules/turbo-windows-64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.6.1.tgz",
-      "integrity": "sha512-buq7/VAN7KOjMYi4tSZT5m+jpqyhbRU2EUTTvp6V0Ii8dAkY2tAAjQN1q5q2ByflYWKecbQNTqxmVploE0LVwQ==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/turbo-windows-64/-/turbo-windows-64-2.7.5.tgz",
+      "integrity": "sha512-rupskv/mkIUgQXzX/wUiK00mKMorQcK8yzhGFha/D5lm05FEnLx8dsip6rWzMcVpvh+4GUMA56PgtnOgpel2AA==",
       "cpu": [
         "x64"
       ],
@@ -20781,9 +20781,9 @@
       ]
     },
     "node_modules/turbo-windows-arm64": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.6.1.tgz",
-      "integrity": "sha512-7w+AD5vJp3R+FB0YOj1YJcNcOOvBior7bcHTodqp90S3x3bLgpr7tE6xOea1e8JkP7GK6ciKVUpQvV7psiwU5Q==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/turbo-windows-arm64/-/turbo-windows-arm64-2.7.5.tgz",
+      "integrity": "sha512-G377Gxn6P42RnCzfMyDvsqQV7j69kVHKlhz9J4RhtJOB5+DyY4yYh/w0oTIxZQ4JRMmhjwLu3w9zncMoQ6nNDw==",
       "cpu": [
         "arm64"
       ],

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "husky": "^9.1.7",
     "localtunnel": "^2.0.2",
     "prettier": "^3.6.2",
-    "turbo": "^2.6.1",
+    "turbo": "^2.7.5",
     "typescript": "5.9.2"
   },
   "engines": {


### PR DESCRIPTION
The following updates have been made:

- **Dependency Update**: Updated `turbo` from version 2.6.1 to 2.7.5. This update ensures compatibility with the latest features and bug fixes in the library.