### PR TITLE
feat(boxes): set `hideTranslation` default state to `true` in `BoxItemPreviewList` component

### DIFF
--- a/apps/app/src/features/boxes/components/box-item-preview-list.tsx
+++ b/apps/app/src/features/boxes/components/box-item-preview-list.tsx
@@ -13,7 +13,7 @@ type Props = Readonly<{
 
 export function BoxItemPreviewList({ boxDetailsItems }: Props) {
   const [hidePhrase, setHidePhrase] = useState(false);
-  const [hideTranslation, setHideTranslation] = useState(false);
+  const [hideTranslation, setHideTranslation] = useState(true);
 
   const hidePhraseId = useId();
   const hideTranslationId = useId();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default display state in box item previews to hide translations by default; users can toggle the switch to reveal them when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->